### PR TITLE
Add values to departments and numberTypes option lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v1.0.1
+
+- Adds values to option lists: departments, numberTypes
+
 ## v1.0.0
 
 ### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-ui-plugin-profile-ohc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OHC profile plugin for the CollectionSpace UI",
   "author": "",
   "license": "ECL-2.0",

--- a/src/plugins/optionLists/shared.js
+++ b/src/plugins/optionLists/shared.js
@@ -23,7 +23,7 @@ export default () => ({
           id: 'option.departments.archaeology',
           defaultMessage: 'Archaeology',
         },
-        archaeology-nagpra: {
+        'archaeology-nagpra': {
           id: 'option.departments.archaeology-nagpra',
           defaultMessage: 'Archaeology - NAGPRA',
         },

--- a/src/plugins/optionLists/shared.js
+++ b/src/plugins/optionLists/shared.js
@@ -9,6 +9,7 @@ export default () => ({
     departments: {
       values: [
         'archaeology',
+        'archaeology-nagpra',  
         'design',
         'education',
         'history',
@@ -21,6 +22,10 @@ export default () => ({
         archaeology: {
           id: 'option.departments.archaeology',
           defaultMessage: 'Archaeology',
+        },
+        archaeology-nagpra: {
+          id: 'option.departments.archaeology-nagpra',
+          defaultMessage: 'Archaeology - NAGPRA',
         },
         education: {
           id: 'option.departments.education',

--- a/src/plugins/optionLists/shared.js
+++ b/src/plugins/optionLists/shared.js
@@ -9,7 +9,7 @@ export default () => ({
     departments: {
       values: [
         'archaeology',
-        'archaeology-nagpra',  
+        'archaeology-nagpra',
         'design',
         'education',
         'history',

--- a/src/plugins/recordTypes/collectionobject/optionLists.js
+++ b/src/plugins/recordTypes/collectionobject/optionLists.js
@@ -391,6 +391,8 @@ export default {
   },
   numberTypes: {
     values: [
+      'AccessCommingledID',
+      'AccessSkeletalID',  
       'Additional File Number',
       'Archives/Library Negative Number',
       'Barcode Number',
@@ -411,6 +413,14 @@ export default {
       'STARid',
     ],
     messages: defineMessages({
+      'AccessCommingledID': {
+        id: 'option.numberTypes.AccessCommingledID',
+        defaultMessage: 'AccessCommingledID',
+      },
+      'AccessSkeletalID': {
+        id: 'option.numberTypes.AccessSkeletalID',
+        defaultMessage: 'AccessSkeletalID',
+      },
       'Additional File Number': {
         id: 'option.numberTypes.Additional File Number',
         defaultMessage: 'Additional File Number',

--- a/src/plugins/recordTypes/collectionobject/optionLists.js
+++ b/src/plugins/recordTypes/collectionobject/optionLists.js
@@ -392,7 +392,7 @@ export default {
   numberTypes: {
     values: [
       'AccessCommingledID',
-      'AccessSkeletalID',  
+      'AccessSkeletalID',
       'Additional File Number',
       'Archives/Library Negative Number',
       'Barcode Number',
@@ -413,11 +413,11 @@ export default {
       'STARid',
     ],
     messages: defineMessages({
-      'AccessCommingledID': {
+      AccessCommingledID: {
         id: 'option.numberTypes.AccessCommingledID',
         defaultMessage: 'AccessCommingledID',
       },
-      'AccessSkeletalID': {
+      AccessSkeletalID: {
         id: 'option.numberTypes.AccessSkeletalID',
         defaultMessage: 'AccessSkeletalID',
       },


### PR DESCRIPTION
Adds values to the `departments` and `numberTypes` option lists. 

These values are required for OHC's new skeletal remains collectionobjects.