### PR TITLE
acquisitionMethod option list changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v1.0.7
+
+- Changes to acquisitionMethods option list values
+  - Remove `curationAgreement` and `gift`
+  - Add `curated-on-behalf-of-federal-government`, `curated-on-behalf-of-state-government`, and `curated-on-behalf-of-tribal-government`
+
 ## v1.0.6
 
 - Adds 'naamcc' (National Afro-American Museum & Cultural Center) and 'poindexter-village' (Poindexter Village) to shared `departments` option list

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-ui-plugin-profile-ohc",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "OHC profile plugin for the CollectionSpace UI",
   "author": "",
   "license": "ECL-2.0",

--- a/src/plugins/recordTypes/acquisition/optionLists.js
+++ b/src/plugins/recordTypes/acquisition/optionLists.js
@@ -4,11 +4,12 @@ export default {
   acquisitionMethods: {
     values: [
       'bequest',
-      'curationAgreement',
+      'curated-on-behalf-of-federal-government',
+      'curated-on-behalf-of-state-government',
+      'curated-on-behalf-of-tribal-government',
       'donation',
       'fieldCollected',
       'foundInCollection',
-      'gift',
       'loan',
       'purchase',
       'staffCurated',
@@ -18,6 +19,18 @@ export default {
       bequest: {
         id: 'option.acquisitionMethods.bequest',
         defaultMessage: 'bequest',
+      },
+      'curated-on-behalf-of-federal-government': {
+        id: 'option.acquisitionMethods.curated-on-behalf-of-federal-government',
+        defaultMessage: 'curated on behalf of federal government',
+      },
+      'curated-on-behalf-of-state-government': {
+        id: 'option.acquisitionMethods.curated-on-behalf-of-state-government',
+        defaultMessage: 'curated on behalf of state government',
+      },
+      'curated-on-behalf-of-tribal-government': {
+        id: 'option.acquisitionMethods.curated-on-behalf-of-tribal-government',
+        defaultMessage: 'curated on behalf of tribal government',
       },
       donation: {
         id: 'option.acquisitionMethods.donation',


### PR DESCRIPTION
For Zendesk ticket 11143

- Changes to acquisitionMethods option list values
  - Remove `curationAgreement` and `gift`
  - Add `curated-on-behalf-of-federal-government`, `curated-on-behalf-of-state-government`, and `curated-on-behalf-of-tribal-government`

**Verified changes are as expected in local dev instance**