### PR TITLE
Add rights mgmt panels to standard object form

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -628,6 +628,77 @@ const template = (configContext) => {
         </CompoundInput>
       </Panel>
 
+      <Panel name="rights" collapsible collapsed>
+        <Field name="rightsGroupList">
+          <Field name="rightsGroup">
+            <Panel>
+              <Row>
+                <Field name="rightType" />
+
+                <Row>
+                  <Field name="rightBeginDate" />
+                  <Field name="rightEndDate" />
+                </Row>
+              </Row>
+
+              <Field name="rightHolderGroupList">
+                <Field name="rightHolderGroup">
+                  <Field name="rightHolder" />
+                  <Field name="rightHolderContact" />
+                </Field>
+              </Field>
+
+              <Row>
+                <Field name="rightJurisdiction" />
+                <Field name="standardizedRightStatement" />
+              </Row>
+
+              <Field name="rightStatement" />
+              <Field name="rightNote" />
+            </Panel>
+          </Field>
+        </Field>
+      </Panel>
+
+      <Panel name="rightsin" collapsible collapsed>
+        <Field name="rightsInGroupList">
+          <Field name="rightsInGroup">
+            <Panel>
+              <Row>
+                <Field name="rightInTypes">
+                  <Field name="rightInType" />
+                </Field>
+
+                <Row>
+                  <Field name="rightInBeginDate" />
+                  <Field name="rightInEndDate" />
+                </Row>
+              </Row>
+
+             <Row>
+               <Field name="agreementSent" />
+               <Field name="agreementReceived" />
+               <Field name="agreementSigned" />
+             </Row>
+
+             <Cols>
+               <Col>
+                 <Field name="rightInRestrictions">
+                   <Field name="rightInRestriction" />
+                 </Field>
+               </Col>
+
+               <Col>
+                 <Field name="rightReproductionStatement" />
+               </Col>
+             </Cols>
+
+             <Field name="rightInNote" />
+            </Panel>
+          </Field>
+        </Field>
+      </Panel>
+
       <Panel name="hierarchy" collapsible collapsed>
         <Field name="relation-list-item" subpath="rel:relations-common-list" />
       </Panel>


### PR DESCRIPTION
These panels were added in 7.1, but because OHC's default object form is customized, the panels were not showing up.

The only other field added to object in anthro 6.0.5 was measuredPartNote, and OHC has that field because its form template calls `extensions.dimension.form`.