### PR TITLE
Zd18704 movement option list changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v1.0.17
+
+- Add option list override for movement recordType, and add custom terms to `moveMethods` option list.
+
 ## v1.0.13
 
 - Add `Detective`, `Lieutenant`, and `Sergeant` to `personTitles` optionList. This required adding `person` recordType override to the plugin.
@@ -38,7 +42,7 @@
 - Adds 'collection-management' to shared `departments` option list
 - Alphabetizes display terms in shared `departments` option list
 
-## v1.0.4 
+## v1.0.4
 
 - Remove the custom single-valued Named Collection field created for OHC, as the profile will now use the multi-valued Named Collection field that has been added to the community profiles
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-ui-plugin-profile-ohc",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "OHC profile plugin for the CollectionSpace UI",
   "author": "",
   "license": "ECL-2.0",

--- a/src/plugins/recordTypes/index.js
+++ b/src/plugins/recordTypes/index.js
@@ -2,6 +2,7 @@ import collectionobject from './collectionobject';
 import conditioncheck from './conditioncheck';
 import acquisition from './acquisition';
 import intake from './intake';
+import movement from './movement';
 import objectexit from './objectexit';
 import person from './person';
 
@@ -10,6 +11,7 @@ export default [
   conditioncheck,
   acquisition,
   intake,
+  movement,
   objectexit,
   person,
 ];

--- a/src/plugins/recordTypes/movement/index.js
+++ b/src/plugins/recordTypes/movement/index.js
@@ -1,0 +1,5 @@
+import optionLists from './optionLists';
+
+export default () => ({
+  optionLists,
+});

--- a/src/plugins/recordTypes/movement/optionLists.js
+++ b/src/plugins/recordTypes/movement/optionLists.js
@@ -1,0 +1,90 @@
+import { defineMessages } from 'react-intl';
+
+export default {
+  moveMethods: {
+    values: [
+      '40" textile box',
+      '60" textile box',
+      'bin box',
+      'blanket wrapped',
+      'crate',
+      'custom box',
+      'drawer',
+      'fragile',
+      'garment rack',
+      'handcarried',
+      'hazardous',
+      'heavy',
+      "large banker's box",
+      'pallet',
+      "small banker's box",
+      'speed pack',
+    ],
+    messages: defineMessages({
+      '40" textile box': {
+        id: 'option.moveMethods.40" textile box',
+        defaultMessage: '40" textile box',
+      },
+      '60" textile box': {
+        id: 'option.moveMethods.60" textile box',
+        defaultMessage: '60" textile box',
+      },
+      'bin box': {
+        id: 'option.moveMethods.bin box',
+        defaultMessage: 'bin box',
+      },
+      'blanket wrapped': {
+        id: 'option.moveMethods.blanket wrapped',
+        defaultMessage: 'blanket wrapped',
+      },
+      crate: {
+        id: 'option.moveMethods.crate',
+        defaultMessage: 'crate',
+      },
+      'custom box': {
+        id: 'option.moveMethods.custom box',
+        defaultMessage: 'custom box',
+      },
+      drawer: {
+        id: 'option.moveMethods.drawer',
+        defaultMessage: 'drawer',
+      },
+      fragile: {
+        id: 'option.moveMethods.fragile',
+        defaultMessage: 'fragile',
+      },
+      'garment rack': {
+        id: 'option.moveMethods.garment rack',
+        defaultMessage: 'garment rack',
+      },
+      handcarried: {
+        id: 'option.moveMethods.handcarried',
+        defaultMessage: 'hand carry',
+      },
+      hazardous: {
+        id: 'option.moveMethods.hazardous',
+        defaultMessage: 'hazardous',
+      },
+      heavy: {
+        id: 'option.moveMethods.heavy',
+        defaultMessage: 'heavy',
+      },
+      "large banker's box": {
+        id: "option.moveMethods.large banker's box",
+        defaultMessage: "large banker's box",
+      },
+      pallet: {
+        id: 'option.moveMethods.pallet',
+        defaultMessage: 'pallet',
+      },
+      "small banker's box": {
+        id: "option.moveMethods.small banker's box",
+        defaultMessage: "small banker's box",
+      },
+      'speed pack': {
+        id: 'option.moveMethods.speed pack',
+        defaultMessage: 'speed pack',
+      },
+    }),
+  },
+};


### PR DESCRIPTION
Add override of movement optionLists and customize terms as requested by client in [Zendesk #18704](https://lyrasis.zendesk.com/agent/tickets/18704)

Tested on anthro.dev by putting its url and tenant id in the index.html of this plugin, which was GREAT to be able to do!