### PR TITLE
Add fields from cspace 7.2

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/archeology-child.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/archeology-child.jsx
@@ -126,6 +126,10 @@ const template = (configContext) => {
         </Row>
         <Row>
           <Col>
+            <Field name="fieldCollectionSites">
+              <Field name="fieldCollectionSite" />
+            </Field>
+
             <Field name="fieldCollectionDateGroup" />
 
             <Field name="fieldCollectionMethods">
@@ -162,6 +166,10 @@ const template = (configContext) => {
           <Col>
             <Field name="objectProductionDateGroupList">
               <Field name="objectProductionDateGroup" />
+            </Field>
+
+            <Field name="objectProductionEras">
+              <Field name="objectProductionEra" />
             </Field>
 
             <Field name="namedTimePeriods" subpath="ns2:collectionobjects_ohc">

--- a/src/plugins/recordTypes/collectionobject/forms/archeology-parent.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/archeology-parent.jsx
@@ -137,6 +137,10 @@ const template = (configContext) => {
 
         <Row>
           <Col>
+            <Field name="fieldCollectionSites">
+              <Field name="fieldCollectionSite" />
+            </Field>
+
             <Field name="fieldCollectionDateGroup" />
 
             <Field name="fieldCollectionMethods">
@@ -173,6 +177,10 @@ const template = (configContext) => {
           <Col>
             <Field name="objectProductionDateGroupList">
               <Field name="objectProductionDateGroup" />
+            </Field>
+
+            <Field name="objectProductionEras">
+              <Field name="objectProductionEra" />
             </Field>
 
             <Field name="namedTimePeriods" subpath="ns2:collectionobjects_ohc">

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -161,6 +161,10 @@ const template = (configContext) => {
         </Row>
         <Row>
           <Col>
+            <Field name="fieldCollectionSites">
+              <Field name="fieldCollectionSite" />
+            </Field>
+
             <Field name="fieldCollectionDateGroup" />
 
             <Field name="fieldCollectionMethods">
@@ -197,6 +201,10 @@ const template = (configContext) => {
           <Col>
             <Field name="objectProductionDateGroupList">
               <Field name="objectProductionDateGroup" />
+            </Field>
+
+            <Field name="objectProductionEras">
+              <Field name="objectProductionEra" />
             </Field>
 
             <Field name="namedTimePeriods" subpath="ns2:collectionobjects_ohc">
@@ -411,6 +419,10 @@ const template = (configContext) => {
                 </Field>
               </Field>
 
+              <Field name="contentEvents">
+                <Field name="contentEvent" />
+              </Field>
+
               <Field name="contentOtherGroupList">
                 <Field name="contentOtherGroup">
                   <Field name="contentOther" />
@@ -544,6 +556,10 @@ const template = (configContext) => {
                 <Field name="assocEventName" />
                 <Field name="assocEventNameType" />
               </InputTable>
+
+              <Field name="assocEvents">
+                <Field name="assocEvent" />
+              </Field>
 
               <Field name="assocEventOrganizations">
                 <Field name="assocEventOrganization" />


### PR DESCRIPTION
This adds missing fields from the CollectionSpace 7.2 release to some of the collectionobject templates.

* Object Production Era
* Field Collection Site
* Associated Event - Controlled
* Content Event - Controlled

I can't deploy this so I didn't test that these work as expected. It's just template changes though so I would expect everything to be ok.