### PR TITLE
Update layout for approval blocks

### DIFF
--- a/src/plugins/recordTypes/acquisition/forms/default.jsx
+++ b/src/plugins/recordTypes/acquisition/forms/default.jsx
@@ -76,11 +76,15 @@ const template = (configContext) => {
 
         <Field name="approvalGroupList">
           <Field name="approvalGroup">
-            <Field name="approvalGroup" />
-            <Field name="approvalIndividual" />
-            <Field name="approvalStatus" />
-            <Field name="approvalDate" />
-            <Field name="approvalNote" />
+            <Panel>
+              <Row>
+                <Field name="approvalGroup" />
+                <Field name="approvalIndividual" />
+                <Field name="approvalStatus" />
+                <Field name="approvalDate" />
+              </Row>
+              <Field name="approvalNote" />
+            </Panel>
           </Field>
         </Field>
         <Field name="acquisitionNote" />

--- a/src/plugins/recordTypes/intake/forms/archeology.jsx
+++ b/src/plugins/recordTypes/intake/forms/archeology.jsx
@@ -48,11 +48,15 @@ const template = (configContext) => {
 
         <Field name="approvalGroupList">
           <Field name="approvalGroup">
-            <Field name="approvalGroup" />
-            <Field name="approvalIndividual" />
-            <Field name="approvalStatus" />
-            <Field name="approvalDate" />
-            <Field name="approvalNote" />
+            <Panel>
+              <Row>
+                <Field name="approvalGroup" />
+                <Field name="approvalIndividual" />
+                <Field name="approvalStatus" />
+                <Field name="approvalDate" />
+              </Row>
+              <Field name="approvalNote" />
+            </Panel>
           </Field>
         </Field>
 

--- a/src/plugins/recordTypes/intake/forms/history.jsx
+++ b/src/plugins/recordTypes/intake/forms/history.jsx
@@ -48,11 +48,15 @@ const template = (configContext) => {
 
         <Field name="approvalGroupList">
           <Field name="approvalGroup">
-            <Field name="approvalGroup" />
-            <Field name="approvalIndividual" />
-            <Field name="approvalStatus" />
-            <Field name="approvalDate" />
-            <Field name="approvalNote" />
+            <Panel>
+              <Row>
+                <Field name="approvalGroup" />
+                <Field name="approvalIndividual" />
+                <Field name="approvalStatus" />
+                <Field name="approvalDate" />
+              </Row>
+              <Field name="approvalNote" />
+            </Panel>
           </Field>
         </Field>
 

--- a/src/plugins/recordTypes/objectexit/forms/default.jsx
+++ b/src/plugins/recordTypes/objectexit/forms/default.jsx
@@ -9,6 +9,7 @@ const template = (configContext) => {
     Panel,
     Cols,
     Col,
+    Row,
   } = configContext.layoutComponents;
 
   const {
@@ -37,11 +38,15 @@ const template = (configContext) => {
 
         <Field name="deacApprovalGroupList">
           <Field name="deacApprovalGroup">
-            <Field name="deaccessionApprovalGroup" />
-            <Field name="deaccessionApprovalIndividual" />
-            <Field name="deaccessionApprovalStatus" />
-            <Field name="deaccessionApprovalDate" />
-            <Field name="deaccessionApprovalNote" />
+            <Panel>
+              <Row>
+                <Field name="deaccessionApprovalGroup" />
+                <Field name="deaccessionApprovalIndividual" />
+                <Field name="deaccessionApprovalStatus" />
+                <Field name="deaccessionApprovalDate" />
+              </Row>
+              <Field name="deaccessionApprovalNote" />
+            </Panel>
           </Field>
         </Field>
 


### PR DESCRIPTION
Jira: https://collectionspace.atlassian.net/browse/DRYD-1429

The approval and deaccessionApproval groups were updated to have the note field be separate from the rest of the data. This updates forms for acquisition, intake, and objectExit so that the `group/individual/status/date` fields are tabular and the note field is separate.

**Did someone actually run this code to verify it works?**
No, though the changes are relatively straightforward and should be ok. I was going to do a quick spot check with the `--backend` flag but there isn't a dev ohc site and I can't seem to resolve the production site properly.