### PR TITLE
Update to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## v3.0.0
+
+- Add 8.1 fields to object template overrides
+  - Add `ethnoFilCode` to archaeology child template
+  - Add `objectCategoryGroupList` to archaeoloy, history, and default templates
+  - Add `objectCountUnit` to archaeology, history, and default templates
+  - Add `publishedRelatedLinkGroupList` to archaeology, history, and default templates
+  - Add `objectProductionPlacesVerbatim` to archaeology and default template
+  - Add `objectCategoryGroupList` to default template
+- Update cspace-ui to 10.0.0
+
 ## v2.0.2
 
 - Remove duplicated value from conditioncheck optionlist: `oxidation`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cspace-ui-plugin-profile-ohc",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cspace-ui-plugin-profile-ohc",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "license": "ECL-2.0",
       "dependencies": {
         "react-intl": "^2.3.0"
@@ -25,7 +25,7 @@
         "chai-as-promised": "^5.3.0",
         "chai-immutable": "^1.6.0",
         "cross-env": "^2.0.0",
-        "cspace-ui": "^10.0.0",
+        "cspace-ui": "^10.0.2",
         "cspace-ui-plugin-profile-anthro": "^9.0.0",
         "css-loader": "^6.7.3",
         "eslint": "^6.7.2",
@@ -4101,10 +4101,11 @@
       "dev": true
     },
     "node_modules/cspace-ui": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/cspace-ui/-/cspace-ui-10.0.0.tgz",
-      "integrity": "sha512-gL/mFPnavhlAmAkGxZw++h+V8h3Sy6me0uQxLL+Xhn/s6mFyEPa91rkElpElC7pvtIQs1i6ztZzIBtTJFdU74A==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/cspace-ui/-/cspace-ui-10.0.2.tgz",
+      "integrity": "sha512-+e2A4YfePlC6pdcetvGxZ0aozqkJ25ksj0DDqdWWribkFR6H50jaAcgCp6ldNdyYSPDYcJVyJ5Phv0nD6xCvpQ==",
       "dev": true,
+      "license": "ECL-2.0",
       "dependencies": {
         "classnames": "^2.2.5",
         "cspace-client": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-ui-plugin-profile-ohc",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "OHC profile plugin for the CollectionSpace UI",
   "author": "",
   "license": "ECL-2.0",
@@ -56,8 +56,8 @@
     "chai-as-promised": "^5.3.0",
     "chai-immutable": "^1.6.0",
     "cross-env": "^2.0.0",
+    "cspace-ui": "^10.0.2",
     "cspace-ui-plugin-profile-anthro": "^9.0.0",
-    "cspace-ui": "^10.0.0",
     "css-loader": "^6.7.3",
     "eslint": "^6.7.2",
     "eslint-config-airbnb": "^18.0.1",


### PR DESCRIPTION
**What does this do?**
Prepares the OHC Profile Plugin for 3.0.0

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1651

I opted for a major version bump because cspace-ui has been updated to 10.0.x. Some of the api calls are reliant on cspace 8.1.0 and as such it's not compatible with previous versions. 

**How should this be tested? Do these changes have associated tests?**
* Ensure `npm run lint`, `npm run test` and `npm run build` pass
* This could also be run against ohc if so desired, e.g.
```
npm run devserver --back-end=https://ohc.collectionspace.url
```

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
No